### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/monkstephen/49bda895-d294-45ca-acc3-7ecb06b07335/b11538cf-1350-42be-8955-5f62f2d08b10/_apis/work/boardbadge/68b9d643-495c-41fa-b14a-9740ea4dfe60)](https://dev.azure.com/monkstephen/49bda895-d294-45ca-acc3-7ecb06b07335/_boards/board/t/b11538cf-1350-42be-8955-5f62f2d08b10/Microsoft.RequirementCategory)
 # AZ-400


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/monkstephen/49bda895-d294-45ca-acc3-7ecb06b07335/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.